### PR TITLE
OpenTelemetry v1.0.0-rc.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21, 22]
+        otp_version: [21, 22, 23, 24]
         os: [ubuntu-latest]
 
     container:

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, [debug_info]}.
+
 {deps, [opentelemetry_api,
         opentelemetry]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,11 @@
 {"1.2.0",
-[{<<"opentelemetry">>,{pkg,<<"opentelemetry">>,<<"0.6.0">>},0},
- {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"0.6.0">>},0}]}.
+[{<<"opentelemetry">>,{pkg,<<"opentelemetry">>,<<"1.0.0-rc.2">>},0},
+ {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.0.0-rc.2">>},0}]}.
 [
 {pkg_hash,[
- {<<"opentelemetry">>, <<"7E7D5A9A66F047DAD3AE7613FC7CEF25AF3C19692663C2F8C00B015E4845592A">>},
- {<<"opentelemetry_api">>, <<"749CCBFC68B3C8347E52492503A67F85DA61ED898E42A592E62DB88D3BCEDF19">>}]},
+ {<<"opentelemetry">>, <<"D3E1FD9DEBFD73E00B0241CAC464BE7CD6CA6AC2BD38AB2EBE0C92401C76A342">>},
+ {<<"opentelemetry_api">>, <<"A0EC5B242BB7CE7563B4891E77DCFA529DEFC9E42C19A5A702574C5AC3D0C6E7">>}]},
 {pkg_hash_ext,[
- {<<"opentelemetry">>, <<"91F486315F7C4183245E1EC146563AE1073EC2044F4D186FABE9CB4841005200">>},
- {<<"opentelemetry_api">>, <<"01D6A2455B42CF3AA225692210510C39727FF92F9612AEA657D1395B642AD44F">>}]}
+ {<<"opentelemetry">>, <<"2F810E2EED70A9EA0C9B6943969B59E37F96A2F9E10920045A6C7676C2AB8181">>},
+ {<<"opentelemetry_api">>, <<"426A969C8EE2AFA8AB55B58E6E40E81C1F934C064459A1ACB530F54042F9A9A3">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,11 @@
 {"1.2.0",
-[{<<"opentelemetry">>,{pkg,<<"opentelemetry">>,<<"0.5.0">>},0},
- {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"0.5.0">>},0}]}.
+[{<<"opentelemetry">>,{pkg,<<"opentelemetry">>,<<"0.6.0">>},0},
+ {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"0.6.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"opentelemetry">>, <<"6A7072A6F54B8BE07A42DD2AACA1EE0389038681405D0A27C4C5E5325B6C1A82">>},
- {<<"opentelemetry_api">>, <<"29ECAA7BB86DF4DBD44B14FD71FD4FAADFF5C08D178545B66B3861BD350BE28A">>}]},
+ {<<"opentelemetry">>, <<"7E7D5A9A66F047DAD3AE7613FC7CEF25AF3C19692663C2F8C00B015E4845592A">>},
+ {<<"opentelemetry_api">>, <<"749CCBFC68B3C8347E52492503A67F85DA61ED898E42A592E62DB88D3BCEDF19">>}]},
 {pkg_hash_ext,[
- {<<"opentelemetry">>, <<"A45261C421240199184D55447108F1D9F49C6B2B0E0E2056AAAA1A1FE77D2EDA">>},
- {<<"opentelemetry_api">>, <<"FA3C23198E84D6D1CDB8A4408374C8D73C9D2EE7A9E587A6D539DEF15851FFAD">>}]}
+ {<<"opentelemetry">>, <<"91F486315F7C4183245E1EC146563AE1073EC2044F4D186FABE9CB4841005200">>},
+ {<<"opentelemetry_api">>, <<"01D6A2455B42CF3AA225692210510C39727FF92F9612AEA657D1395B642AD44F">>}]}
 ].


### PR DESCRIPTION
💁 These changes upgrade the OpenTelemetry dependencies for this library to version ~0.6.0~ 1.0.0-rc.2.

I've also taken the liberty of adding OTP versions 23 and 24 to the build matrix as well.